### PR TITLE
docs: update readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,17 +4,9 @@
 
 # Spoonbill
 
-What is Spoonbill? Inspired by [ibis](https://ibis-project.org/docs/3.2.0/)
-Spoonbill is a Python library that provides a lightweight, universal interface for Key-Values data stores. Write once,
-run anywhere.
+Spoonbill is a Python library that provides a lightweight, universal interface for Key-Values data stores. It is particularly useful for fast prototyping, testing, and simplification of data pipelines. Inspired by [ibis](https://ibis-project.org/docs/3.2.0/).
 
-For fast prototyping, testing, and simplification of data pipelines.
-
-## Features
-
-1. A `strict=False` mode is available to allow for more flexible data types - anything which is cloudpickle-able will
-   work including classes and functions.
-2. A unified interface for all data stores.
+Write once, run anywhere.
 
 ## Installation
 
@@ -22,14 +14,19 @@ For fast prototyping, testing, and simplification of data pipelines.
 pip install spoonbill
 ```
 
+## Features
+
+1. A unified interface for all data stores.
+2. A `strict=False` mode is available to allow for more flexible data types - anything which is `cloudpickle`-able will work, including classes and functions.
+
 ## Operations map
 
-* For scan operations, you need to use a keys as strings.
+* For scan operations, you need to use keys as strings.
 
-| Operation                    | InMemoryDict | BucketDict                 | RedisDict                                  | LmdbDict                                            | PysosDict                                   | ShelveDict                                              | DynamoDBDict                                     | FireStoreDict                                               | CosmosDB                                                                                               | MongoDbDict                             |
+| Operation                    | InMemoryDict | BucketStore                | RedisDict                                  | LmdbDict                                            | PysosDict                                   | ShelveDict                                              | DynamoDBDict                                     | FireStoreDict                                               | CosmosDB                                                                                               | MongoDbDict                             |
 |------------------------------|--------------|----------------------------|--------------------------------------------|-----------------------------------------------------|---------------------------------------------|---------------------------------------------------------|--------------------------------------------------|-------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|-----------------------------------------|
 | backend                      | python dict  | S3/GS/AZ buckets           | [Redis](https://github.com/redis/redis-py) | [Lmdb](https://github.com/Dobatymo/lmdb-python-dbm) | [Pysos](https://github.com/dagnelies/pysos) | [Shelve](https://docs.python.org/3/library/shelve.html) | [AWS DynamoDB](https://aws.amazon.com/dynamodb/) | [GCP Firestore](https://firebase.google.com/docs/firestore) | [Azure Cosmos DB](https://www.google.com/search?client=safari&rls=en&q=Azure+Cosmos&ie=UTF-8&oe=UTF-8) | [MongoDB](https://www.mongodb.com/home) |
-| set                          | √            | √                          | √                                          | √                                                   | √                                           | √                                                       | √                                                | √                                                           | √                                                                                                      | √                                       | 
+| set                          | √            | √                          | √                                          | √                                                   | √                                           | √                                                       | √                                                | √                                                           | √                                                                                                      | √                                       |
 | get                          | √            | √                          | √                                          | √                                                   | √                                           | √                                                       | √                                                | √                                                           | √                                                                                                      | √                                       |
 | pop                          | √            | √                          | √                                          | √                                                   | √                                           | √                                                       | √                                                | √                                                           | √                                                                                                      | √                                       |
 | delete                       | √            | √                          | √                                          | √                                                   | √                                           | √                                                       | √                                                | √                                                           | √                                                                                                      | √                                       |
@@ -50,10 +47,9 @@ pip install spoonbill
 
 ## Usage
 
-All the classes have the same interface, so you can use them interchangeably.
+All classes have the same interface, so you can use them interchangeably.
 
-* The *strict* argument is used to control if to encode the keys and values with cloudpickle or keep original behavior.
-  if strict is False, any key and value can be used, otherwise it depends on the backend.
+* The `strict` argument is used to control whether to encode the keys and values with cloudpickle or keep original behavior. If `strict=False`, any key and value can be used, otherwise it depends on the backend.
 
 ## APIs
 
@@ -85,10 +81,9 @@ store.load('path')
 
 ### InMemoryDict
 
-This object is to have a common interface for all the key-value stores. It is great for testing and for the average use
-case, to have a common interface which includes the scan operation.
+This object is a common interface for all the key-value stores, and it also includes the scan operation. It is great for testing and for standard use-cases.
 
-* Save/load are implemented to save/load the whole dict to/from a file, locally or on the cloud
+* `save`/`load` are saving and loading the whole dict to or from a file, locally or on the cloud
   using [cloudpathlib](https://cloudpathlib.drivendata.org/stable/).
 
 ```python
@@ -102,17 +97,13 @@ from collections import defaultdict, OrderedDict, Counter
 store = InMemoryStore(defaultdict)
 store = InMemoryStore(OrderedDict)
 store = InMemoryStore(Counter)
-``` 
+```
 
-### BucketDict
+### BucketStore
 
-Requirements:   
-```pip install cloudpathlib```
+This dict is implemented as key-value files locally or on a cloud provider (S3, GS, AZ). It is **very slow**, but good to use as a cheap persisted key-value store.
 
-This dict is implemented as key-value files locally or on a cloud provider (S3, GS, AZ). It is **very slow**, but good
-for as a cheap persisted key-value stor.
-
-For faster applications with cloud persistence, use InMemoryStore/LmdbStore and save/load to the cloud.
+For faster applications with cloud persistence, use `InMemoryStore`/`LmdbStore` and save/load to the cloud.
 
 ## Persisted dictionaries
 
@@ -120,11 +111,8 @@ Dictionaries which are persisted to disk.
 
 ### LmdbStore
 
-LmdbDict is a wrapper around the [lmdb-python-dbm](lmdb-python-dbm) library.    
-It is a fast key-value with memory-mapped persistence.
-
-Requirements:   
-```pip install lmdbm```
+`LmdbDict` is a wrapper around the [lmdb-python-dbm](lmdb-python-dbm) library.
+It is a fast key-value store with memory-mapped persistence.
 
 ```python
 from spoonbill.datastores import LmdbStore
@@ -134,11 +122,8 @@ store = LmdbStore.open('tmp.db')
 
 ### PysosStore
 
-A wrapper around the [pysos](https://github.com/dagnelies/pysos) library.      
-This is ideal for lists or dictionaries which either need persistence, are too big to fit in memory or both.
-
-Requirements:   
-```pip install pysos```
+A wrapper around the [pysos](https://github.com/dagnelies/pysos) library.
+This is ideal for lists or dictionaries that either need persistence, are too big to fit in memory, or both.
 
 ```python
 from spoonbill.datastores import PysosStore
@@ -148,14 +133,14 @@ store = PysosStore.open('tmp.db')
 
 ### RedisStore
 
-A wrapper around [redis-py](https://github.com/redis/redis-py) library.
+A wrapper around the [redis-py](https://github.com/redis/redis-py) library.
 
-* When strict=False any key-value can be used, otherwise only string keys and values can be used.
+* When `strict=False` any key-value can be used, otherwise only string keys and values are accepted.
 
 ```python
 from spoonbill.datastores import RedisStore
 
-# set strict to True to use redis with its default behaviour which turns keys and values to strings
+# set `strict=True` to use redis with its default behaviour which turns keys and values to strings
 store = RedisStore.open("redis://localhost:6379/1")
 store[1] = 1
 assert store[1] == store["1"] == "1"
@@ -168,7 +153,7 @@ store[1] = lambda x: x + 1  # anything goes using cloudpickle
 assert store[1](1) == 2
 ```
 
-Question: What is the difference between *keys* and *scan*?     
+Question: What is the difference between *keys* and *scan*?
 Answer: *keys()* is faster and blocking, while scan is (slightly) slower and non-blocking.
 
 ## Serverless stores
@@ -184,21 +169,16 @@ Notes:
 * It is always recommended to set values which are a dict {attribute_name: value} to enjoy all the dynamodb features.
 * Keys are defined per table as either strings ('S'), numbers ('N') or bytes ('B').
 * If you set a primitive number value, it will return as float (:
-* cerealbox is required for *get_batch*: ```pip install cerealbox```
-
-Requirements:
-
-```bash
-pip install boto3 
-```
+* `cerealbox` is required for `get_batch`: ```pip install cerealbox```
 
 ### [Firestore]((https://firebase.google.com/docs/firestore))
 
 Notes:
 
 * It is recommended use dict-values {attribute_name: value} + `strict=True` to enjoy all the firestore features.
-    * Example: `store['key'] = {'feature': 'value'}`   
-      Prerequisites:
+    * Example: `store['key'] = {'feature': 'value'}`
+
+Prerequisites:
 
 1. Create a project in Google Cloud Platform
 2. Enable Firestore API
@@ -206,10 +186,10 @@ Notes:
 4. Set the environment variable GOOGLE_APPLICATION_CREDENTIALS to the path of the json file
 5. Create a database in Firestore
 6. Create a collection in the database
-7. Install google-cloud-firestore with
+7. Install `google-cloud-firestore` with
 
 ```bash
-pip install --upgrade google-cloud-firestore 
+pip install --upgrade google-cloud-firestore
 ```
 
 ```python
@@ -243,7 +223,7 @@ store = CosmosDBStore.open(database='db',
 
 ### [MongoDB]((https://www.mongodb.com/home))
 
-* Save/load is only implemented for `strict=True`.
+* `save`/`load` is only implemented for `strict=True`.
 
 Requirements:
 


### PR DESCRIPTION
A series of small fixes & language improvements to the readme. 
Notable changes:
- Removed `pip install <lib>` whenever that lib is part of the requirements.txt
  - done for `cloudpathlib`, `boto3` , `lmdbm`, `pysos`
- Renamed `BucketStore` to `BucketStore` to match the codebase
- Small grammar, typos and readability fixes - feel free to revert / disagree wherever. 

Please check that I've not inadvertently changed the meaning of anything..